### PR TITLE
Fix #2

### DIFF
--- a/cypress/e2e/todo.cy.js
+++ b/cypress/e2e/todo.cy.js
@@ -58,6 +58,45 @@ describe("example to-do app", () => {
       cy.contains("Take out the trash").should("not.exist");
     });
 
+    it("can edit filtered todo correctly (bug #2 fix)", () => {
+      cy.contains("Active").click();
+
+      cy.get(".todo-list li")
+        .should("have.length", 1)
+        .first()
+        .find("label")
+        .should("have.text", "Do the dishes");
+
+      cy.get(".todo-list li")
+        .first()
+        .find('.editTask button')
+        .click({ force: true })
+
+      cy.get(".todo-list li")
+        .first()
+        .find('input.TodoForm')
+        .type(` (edited){enter}`)
+      
+      cy.get(".todo-list li")
+        .should("have.length", 1)
+        .first()
+        .find("label")
+        .should("have.text", "Do the dishes (edited)");
+
+      cy.contains("All").click();
+
+      cy.get(".todo-list li")
+        .should("have.length", 2)
+        .first()
+        .find("label")
+        .should("have.text", "Take out the trash");
+
+      cy.get(".todo-list li:nth(1)")
+          .find("label")
+          .should("have.text", "Do the dishes (edited)");
+
+    });
+
     it("can filter for completed todos", () => {
       cy.contains("Completed").click();
 

--- a/src/Todo/TodoList.tsx
+++ b/src/Todo/TodoList.tsx
@@ -46,7 +46,7 @@ const TodoListItem = ({ item, index, edit, onEdit, onSubmit, onComplete }: TodoL
 };
 
 const TodoList = memo(({ todo, filter, dispatch }: TodoListProps) => {
-  const [editIndex, updateIndex] = useState<null|number>(null);
+  const [editIndex, updateIndex] = useState<null|string>(null);
   const applyFilters = (item: Task) => {
     switch (filter) {
       case "active": {
@@ -73,17 +73,17 @@ const TodoList = memo(({ todo, filter, dispatch }: TodoListProps) => {
                 item={item}
                 key={item.id}
                 index={i}
-                onEdit={() => updateIndex(i)}
+                onEdit={() => updateIndex(item.id)}
                 onSubmit={(value) => {
-                  dispatch({ type: 'update', id: i, value });
+                  dispatch({ type: 'update', id: item.id, value });
                   updateIndex(null);
                   return value;
                 }}
                 onComplete={() => {
                   console.log(`dispatch invoked`);
-                  dispatch({ type: 'completed', id: i });
+                  dispatch({ type: 'completed', id: item.id });
                 }}
-                edit={editIndex === i}
+                edit={editIndex === item.id}
               />
             ))
           }

--- a/src/Todo/useTodoState.tsx
+++ b/src/Todo/useTodoState.tsx
@@ -21,8 +21,8 @@ export type Action = { type: 'new', newItem: string }
   | { type: 'filterCompleted' }
   | { type: 'filterAll' }
   | { type: 'clearCompleted' }
-  | { type: 'completed', id: number }
-  | { type: 'update', value: string, id: number }
+  | { type: 'completed', id: string }
+  | { type: 'update', value: string, id: string }
   | { type: 'restore', todo: Task[] }
 
 
@@ -81,7 +81,7 @@ const reducer = (state: State, action: Action): State => {
         type: 'complete',
         appID
       });
-      const todo = state.todo.map((item, i) => i === action.id ? { ...item, completed: !item.completed } : item);
+      const todo = state.todo.map((item, i) => item.id === action.id ? { ...item, completed: !item.completed } : item);
       updateTodoStorage(todo);
       return {...state, todo};
     }
@@ -92,7 +92,7 @@ const reducer = (state: State, action: Action): State => {
         type: 'update',
         appID
       });
-      const todo = state.todo.map((item, i) => i === action.id ? { ...item, value: action.value } : item);
+      const todo = state.todo.map((item, i) => item.id === action.id ? { ...item, value: action.value } : item);
       updateTodoStorage(todo);
       return {...state, todo};
     }


### PR DESCRIPTION
The following PR addresses a bug with editing todos while in other filtered views of the list. Previously, updates to those items were dispatched and identified the record to update by using the index in the list rather than the UUID. This resulted in editing items in the complete list using a filtered view with fewer todos, which creates a mismatch in the index being edited versus the index of the same item in the unfiltered list.